### PR TITLE
Document macOS deployment target

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ pinned fork of CocoaSpice: https://github.com/allisonfm85/CocoaSpice
 
 Building requires Xcode on Apple Silicon, the UTM sysroot placed at the
 path named in the Run Script build phase (or edit the script to match
-your location), and macOS 13 Ventura or later as the deployment target.
+your location), and macOS 26.5 or later as the deployment target, matching
+the current Xcode project configuration.
 The bundled xorriso must be 1.5.8.pl02 or later — earlier versions
 produce install ISOs the Windows boot loader cannot read.
 


### PR DESCRIPTION
## Summary

- update the documented macOS deployment target from macOS 13 to macOS 26.5
- note that the requirement matches the current Xcode project configuration

## Why

The README contradicted both Debug and Release `MACOSX_DEPLOYMENT_TARGET` settings in the Xcode project. This could lead contributors to expect the project to build for an unsupported macOS version.

## Impact

Contributors now see the actual deployment requirement when reviewing the source-build prerequisites. There is no application behavior change.

## Validation

- confirmed both Xcode build configurations specify macOS 26.5
- ran `git diff --check`
